### PR TITLE
chore(homepage): add short-title "MDN"

### DIFF
--- a/files/config.json
+++ b/files/config.json
@@ -27,6 +27,7 @@
     "": {
       "slug": "",
       "pageTitle": "MDN Web Docs",
+      "shortTitle": "MDN",
       "trailingSlash": true,
       "data": {
         "homePage": {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds a short-title `"MDN"` for the homepage.

### Motivation

Although "MDN Web Docs" makes sense for the `<title>`, it doesn't necessarily make sense for the breadcrumbs, where it could also appear as the parent item for About, Community, Playground etc.

### Additional details

This is currently only visible in Fred: https://fred.review.mdn.allizom.net/en-US/

### Related issues and pull requests

Needs: https://github.com/mdn/rari/pull/274
