### PR TITLE
ci(workflows): use latest compatible node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version-file: mdn/content/.nvmrc
+          check-latest: true
           cache: npm
           cache-dependency-path: mdn/content/package-lock.json
 


### PR DESCRIPTION
### Description

Updates all workflow steps using `actions/setup-node`, setting `check-latest: true`.

### Motivation

Ensures the latest compatible Node version is used consistently, with the corresponding npm version.

### Additional details


### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1309.
