### PR TITLE
fix(ci): pin npx rari to @mdn/rari package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           GENERIC_CONTENT_ROOT: ${{ github.workspace }}/mdn/generic-content/files
           GITHUB_TOKEN: ${{ github.token }}
-        run: npx rari build --no-basic --generics --issues "$BUILD_OUT_ROOT/issues.json" --templ-stats
+        run: npx @mdn/rari build --no-basic --generics --issues "$BUILD_OUT_ROOT/issues.json" --templ-stats
 
       - name: Report
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
## Description

- `.github/workflows/test.yml`: `npx rari …` → `npx @mdn/rari …`

## Motivation

Prevent a dependency-confusion fallback in `npx rari`.

## Additional details

`npx rari` resolves to the local `rari` bin only when present; otherwise npm silently downloads and runs a registry package literally named `rari` — owned by an unrelated third party, not MDN (MDN's package is the scoped `@mdn/rari`). In CI, `npx` assumes `--yes`, so the fallback fetch happens with no prompt. Invoking `@mdn/rari` directly guarantees the intended bin.

## Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1680.
